### PR TITLE
Upgrade a failing make command's exit code to 255

### DIFF
--- a/includes/All.mk
+++ b/includes/All.mk
@@ -1,2 +1,2 @@
 all: ## Runs everything ####
-	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sed 's/[^:]*://' | grep -v "####" | awk 'BEGIN {FS = ":.*?## "}; {printf "%s\n", $$1}' | xargs --open-tty -I % bash -c 'cd $$PWD && $(MAKE) %'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sed 's/[^:]*://' | grep -v "####" | awk 'BEGIN {FS = ":.*?## "}; {printf "%s\n", $$1}' | xargs --open-tty -I % bash -c 'cd $$PWD && $(MAKE) % || exit 255'


### PR DESCRIPTION
As per the last sentence of https://man7.org/linux/man-pages/man1/xargs.1.html#DESCRIPTION, exiting anything with `255` will stop `make` from invoke the next command. So by taken any non-`0` exit code and turn it into `255` will short-circuit the loop,