### PR TITLE
Add OTEL fiber env var for async applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ else
 		-v "`pwd`:`pwd`" \
 		-v "${COMPOSER_CACHE_DIR}:${COMPOSER_CONTAINER_CACHE_DIR}" \
 		-w "`pwd`" \
+		-e OTEL_PHP_FIBERS_ENABLED="true" \
 		"${CONTAINER_NAME}"
 endif
 

--- a/templates/Makefile.PHP
+++ b/templates/Makefile.PHP
@@ -26,6 +26,7 @@ else
 		-v "`pwd`:`pwd`" \
 		-v "${COMPOSER_CACHE_DIR}:${COMPOSER_CONTAINER_CACHE_DIR}" \
 		-w "`pwd`" \
+		-e OTEL_PHP_FIBERS_ENABLED="true" \
 		"${CONTAINER_NAME}"
 endif
 


### PR DESCRIPTION
Without this async, or any async/fiber package will be getting these kind of errors:
![image](https://github.com/user-attachments/assets/9e34b8ab-c1ae-4e90-99c6-4938fd980892)
