### PR TITLE
Only `update-lock` when `composer.json` changes while running `composer-normalize`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,8 +436,10 @@ syntax-php: ## Lint PHP syntax ##*ILH*##
 	$(DOCKER_RUN) vendor/bin/parallel-lint --exclude vendor .
 
 composer-normalize: ## Normalize composer.json ##*I*##
-	$(DOCKER_RUN) composer normalize
-	$(MAKE) update-lock
+	@before="$$( $(DOCKER_RUN) php -r 'echo hash_file("sha512", "composer.json");' )"; \
+	$(DOCKER_RUN) composer normalize --no-update-lock; \
+	after="$$( $(DOCKER_RUN) php -r 'echo hash_file("sha512", "composer.json");' )"; \
+	[ "$$before" = "$$after" ] || $(MAKE) update-lock
 
 rector-upgrade: ## Upgrade any automatically upgradable old code ##*I*##^code-style^##
 	$(DOCKER_RUN) vendor/bin/rector -c ./etc/qa/rector.php

--- a/includes/PHP.mk
+++ b/includes/PHP.mk
@@ -5,8 +5,10 @@ syntax-php: ## Lint PHP syntax ##*ILH*##
 	$(DOCKER_RUN) vendor/bin/parallel-lint --exclude vendor .
 
 composer-normalize: ## Normalize composer.json ##*I*##
-	$(DOCKER_RUN) composer normalize
-	$(MAKE) update-lock
+	@before="$$( $(DOCKER_RUN) php -r 'echo hash_file("sha512", "composer.json");' )"; \
+	$(DOCKER_RUN) composer normalize --no-update-lock; \
+	after="$$( $(DOCKER_RUN) php -r 'echo hash_file("sha512", "composer.json");' )"; \
+	[ "$$before" = "$$after" ] || $(MAKE) update-lock
 
 rector-upgrade: ## Upgrade any automatically upgradable old code ##*I*##^code-style^##
 	$(DOCKER_RUN) vendor/bin/rector -c ./etc/qa/rector.php


### PR DESCRIPTION
The goal is to skip always running composer plugins etc when we do this on every `make` run. This can have some weird side effects some how...