### PR TITLE
Pin Infection to one thread in CI via `MUTATION_THREADS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ else
     IN_CI=FALSE
 endif
 
+ifeq ("$(IN_CI)","TRUE")
+    MUTATION_THREADS?=1
+else
+    MUTATION_THREADS?=$(THREADS)
+endif
+
 ifeq ("$(IN_DOCKER)","TRUE")
 	DOCKER_RUN:=
 	DOCKER_RUN_WITHOUT_NETWORK_FOR_COMPOSER:=
@@ -46,7 +52,7 @@ ifeq ("$(IN_DOCKER)","TRUE")
 else
     ifeq ($(DOCKER_AVAILABLE),0)
         DOCKER_DEFAULT_SECURITY_OPS=--cap-drop=ALL --security-opt="no-new-privileges=true" --user="`id -u`:`id -g`"
-        DOCKER_COMMON_OPS:=-v "`pwd`:`pwd`" -w "`pwd`" -v "`pwd`/.git:`pwd`/.git:ro" -v "${COMPOSER_CACHE_DIR}:${COMPOSER_CONTAINER_CACHE_DIR}" --ulimit nofile=1000000 -e THREADS="${THREADS}" -e OTEL_PHP_DISABLED_INSTRUMENTATIONS="all"
+        DOCKER_COMMON_OPS:=-v "`pwd`:`pwd`" -w "`pwd`" -v "`pwd`/.git:`pwd`/.git:ro" -v "${COMPOSER_CACHE_DIR}:${COMPOSER_CONTAINER_CACHE_DIR}" --ulimit nofile=1000000 -e THREADS="${THREADS}" -e MUTATION_THREADS="${MUTATION_THREADS}" -e OTEL_PHP_DISABLED_INSTRUMENTATIONS="all"
         ifneq ("$(wildcard etc/qa/zzz_disable_otel_attr_hooks.ini)","")
             DOCKER_COMMON_OPS:=${DOCKER_COMMON_OPS} -v "`pwd`/etc/qa/zzz_disable_otel_attr_hooks.ini:/usr/local/etc/php/conf.d/zzz_disable_otel_attr_hooks.ini:ro"
         endif
@@ -480,10 +486,10 @@ coverage-guard-raw: ## Enforce code coverage rules ####
 	php vendor/bin/coverage-guard check ./var/phpunit/coverage/clover.xml --config=./etc/qa/coverage-guard.php
 
 mutation-testing: ## Run mutation testing ##*LCH*##^static-analysis|unit-tests^##
-	$(DOCKER_RUN_WITH_SOCKET) vendor/bin/infection --ansi --log-verbosity=all --ignore-msi-with-no-mutations --configuration=./etc/qa/infection.json5 --static-analysis-tool=phpstan --static-analysis-tool-options="--memory-limit=-1" --threads=$(THREADS)
+	$(DOCKER_RUN_WITH_SOCKET) vendor/bin/infection --ansi --log-verbosity=all --ignore-msi-with-no-mutations --configuration=./etc/qa/infection.json5 --static-analysis-tool=phpstan --static-analysis-tool-options="--memory-limit=-1" --threads=$(MUTATION_THREADS)
 
 mutation-testing-raw: ## Run mutation testing ####^static-analysis|unit-tests^##
-	vendor/bin/infection --ansi --log-verbosity=all --ignore-msi-with-no-mutations --configuration=./etc/qa/infection.json5 --static-analysis-tool=phpstan --static-analysis-tool-options="--memory-limit=-1" --threads=$(THREADS)
+	vendor/bin/infection --ansi --log-verbosity=all --ignore-msi-with-no-mutations --configuration=./etc/qa/infection.json5 --static-analysis-tool=phpstan --static-analysis-tool-options="--memory-limit=-1" --threads=$(MUTATION_THREADS)
 
 composer-require-checker: ## Ensure we require every package used in this package directly ##*EC*##^composer-dependency-checkers^##
 	$(DOCKER_SHELL) vendor/bin/composer-require-checker --ignore-parse-errors --ansi -vvv --config-file=./etc/qa/composer-require-checker.json

--- a/includes/PHP.mk
+++ b/includes/PHP.mk
@@ -48,11 +48,11 @@ coverage-guard-raw: ## Enforce code coverage rules ####
 
 mutation-testing: ## Run mutation testing ##*LCH*##^static-analysis|unit-tests^##
 	service_start(before-unit-tests-service)
-	$(DOCKER_RUN_WITH_SOCKET) vendor/bin/infection --ansi --log-verbosity=all --ignore-msi-with-no-mutations --configuration=./etc/qa/infection.json5 --static-analysis-tool=phpstan --static-analysis-tool-options="--memory-limit=-1" --threads=$(THREADS)
+	$(DOCKER_RUN_WITH_SOCKET) vendor/bin/infection --ansi --log-verbosity=all --ignore-msi-with-no-mutations --configuration=./etc/qa/infection.json5 --static-analysis-tool=phpstan --static-analysis-tool-options="--memory-limit=-1" --threads=$(MUTATION_THREADS)
 	service_cleanup(after-unit-tests-service)
 
 mutation-testing-raw: ## Run mutation testing ####^static-analysis|unit-tests^##
-	vendor/bin/infection --ansi --log-verbosity=all --ignore-msi-with-no-mutations --configuration=./etc/qa/infection.json5 --static-analysis-tool=phpstan --static-analysis-tool-options="--memory-limit=-1" --threads=$(THREADS)
+	vendor/bin/infection --ansi --log-verbosity=all --ignore-msi-with-no-mutations --configuration=./etc/qa/infection.json5 --static-analysis-tool=phpstan --static-analysis-tool-options="--memory-limit=-1" --threads=$(MUTATION_THREADS)
 
 composer-require-checker: ## Ensure we require every package used in this package directly ##*EC*##^composer-dependency-checkers^##
 	$(DOCKER_SHELL) vendor/bin/composer-require-checker --ignore-parse-errors --ansi -vvv --config-file=./etc/qa/composer-require-checker.json

--- a/templates/Makefile.PHP
+++ b/templates/Makefile.PHP
@@ -37,6 +37,12 @@ else
     IN_CI=FALSE
 endif
 
+ifeq ("$(IN_CI)","TRUE")
+    MUTATION_THREADS?=1
+else
+    MUTATION_THREADS?=$(THREADS)
+endif
+
 ifeq ("$(IN_DOCKER)","TRUE")
 	DOCKER_RUN:=
 	DOCKER_RUN_WITHOUT_NETWORK_FOR_COMPOSER:=
@@ -46,7 +52,7 @@ ifeq ("$(IN_DOCKER)","TRUE")
 else
     ifeq ($(DOCKER_AVAILABLE),0)
         DOCKER_DEFAULT_SECURITY_OPS=--cap-drop=ALL --security-opt="no-new-privileges=true" --user="`id -u`:`id -g`"
-        DOCKER_COMMON_OPS:=-v "`pwd`:`pwd`" -w "`pwd`" -v "`pwd`/.git:`pwd`/.git:ro" -v "${COMPOSER_CACHE_DIR}:${COMPOSER_CONTAINER_CACHE_DIR}" --ulimit nofile=1000000 -e THREADS="${THREADS}" -e OTEL_PHP_DISABLED_INSTRUMENTATIONS="all"
+        DOCKER_COMMON_OPS:=-v "`pwd`:`pwd`" -w "`pwd`" -v "`pwd`/.git:`pwd`/.git:ro" -v "${COMPOSER_CACHE_DIR}:${COMPOSER_CONTAINER_CACHE_DIR}" --ulimit nofile=1000000 -e THREADS="${THREADS}" -e MUTATION_THREADS="${MUTATION_THREADS}" -e OTEL_PHP_DISABLED_INSTRUMENTATIONS="all"
         ifneq ("$(wildcard etc/qa/zzz_disable_otel_attr_hooks.ini)","")
             DOCKER_COMMON_OPS:=${DOCKER_COMMON_OPS} -v "`pwd`/etc/qa/zzz_disable_otel_attr_hooks.ini:/usr/local/etc/php/conf.d/zzz_disable_otel_attr_hooks.ini:ro"
         endif

--- a/tests/Composer/ExtraServicesDetectionTest.php
+++ b/tests/Composer/ExtraServicesDetectionTest.php
@@ -81,9 +81,24 @@ final class ExtraServicesDetectionTest extends TestCase
         self::assertIsString($template);
         self::assertStringContainsString('ifeq ("$(GITHUB_ACTIONS)","true")', $template);
         self::assertStringContainsString('IN_CI=FALSE', $template);
+        self::assertStringContainsString('MUTATION_THREADS?=$(THREADS)', $template);
+        self::assertStringContainsString('ifeq ("$(IN_CI)","TRUE")', $template);
+        self::assertStringContainsString('MUTATION_THREADS?=1', $template);
+        self::assertStringContainsString('-e MUTATION_THREADS="${MUTATION_THREADS}"', $template);
         self::assertStringNotContainsString('include includes/Services.mk', $template);
         self::assertStringNotContainsString('RUN_WITH_EXTRA_SERVICES', $template);
         self::assertStringNotContainsString('EXTRA_SERVICES_DOCKER_NETWORK', $template);
+    }
+
+    #[Test]
+    public function phpMkUsesMutationThreadsForInfection(): void
+    {
+        $phpMkPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'PHP.mk';
+        $phpMk     = file_get_contents($phpMkPath);
+
+        self::assertIsString($phpMk);
+        self::assertStringContainsString('--threads=$(MUTATION_THREADS)', $phpMk);
+        self::assertStringNotContainsString('--threads=$(THREADS)', $phpMk);
     }
 
     #[Test]


### PR DESCRIPTION
Avoids parallel PHPStan DCD cache races during mutation testing.